### PR TITLE
Verify app image rendering and display

### DIFF
--- a/src/components/AppCard.tsx
+++ b/src/components/AppCard.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import { ExternalLink, Info } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { SolidApp } from '@/lib/rdfUtils';
-import { generateAppColor, generateInitials, isValidImageUrl } from '@/lib/imageUtils';
+import { generateAppColor, generateInitials } from '@/lib/imageUtils';
 
 interface AppCardProps {
   app: SolidApp;
@@ -13,7 +13,8 @@ interface AppCardProps {
 export default function AppCard({ app, index }: AppCardProps) {
   const [imageError, setImageError] = useState(false);
   const [imageLoading, setImageLoading] = useState(true);
-  const hasValidImage = isValidImageUrl(app.image) && !imageError;
+  // Attempt to render an image whenever a URL is provided. If loading fails, we fall back gracefully via the onError handler.
+  const hasValidImage = Boolean(app.image) && !imageError;
   const appColor = generateAppColor(app.name);
   const initials = generateInitials(app.name);
 

--- a/src/components/__tests__/AppCard.test.tsx
+++ b/src/components/__tests__/AppCard.test.tsx
@@ -90,4 +90,26 @@ describe('AppCard', () => {
     const image = screen.getByAltText('Test Application');
     expect(image).toHaveAttribute('crossorigin', 'anonymous');
   });
+
+  it('shows the loaded image and hides placeholder after load event', async () => {
+    render(<AppCard app={mockApp} index={0} />);
+
+    const image = screen.getByAltText('Test Application');
+
+    // Placeholder with initials should be visible initially
+    expect(screen.getByText('TA')).toBeInTheDocument();
+
+    // Fire the synthetic load event to simulate a successful image download
+    await act(async () => {
+      const loadEvent = new Event('load', { bubbles: true });
+      image.dispatchEvent(loadEvent);
+    });
+
+    await waitFor(() => {
+      // Placeholder should disappear once the image has loaded
+      expect(screen.queryByText('TA')).not.toBeInTheDocument();
+      // Image should now have full opacity indicating it is visible
+      expect(image.className).toContain('opacity-100');
+    });
+  });
 });


### PR DESCRIPTION
Ensure app images are displayed reliably and add a test to confirm browser rendering.

The previous `isValidImageUrl` check was overly strict, preventing valid image URLs from being attempted. This change simplifies the logic to always attempt loading an image if a URL is provided, relying on the `onError` handler for graceful fallback. A new test case has been added to explicitly verify that the image element becomes visible in the DOM after a successful load event, addressing the "rendered in the browser" requirement.

---

[Open in Web](https://cursor.com/agents?id=bc-804b5772-30a8-4625-8b17-0ca0e75e2427) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-804b5772-30a8-4625-8b17-0ca0e75e2427) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)